### PR TITLE
Add global acme_sh_staging variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Role Variables
 --------------
 
 See `defaults/main.yml`. It is important to read the notes on how to configure the role. Namely,
-you will want to ensure that `acme_sh_env` is changed from the default value (which points to the
-ACME staging server), at least when you want to generate real SSL certificates.
+you will want to ensure that `acme_sh_staging` is changed from the default value to use the
+non-staging Let's Encrypt endpoint when you want to generate production certificates.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,8 +34,12 @@ acme_sh_secondary_domains: []
 
 # Arguments to include before the domain arguments when issuing a certificate. The typical use for
 # this is to pass --nginx or --apache when you want acme.sh to automatically perform the http-01
-# challenge. If you aren't using either of those, set this to blank to use live mode.
-acme_sh_issue_prefix: '--staging'
+# challenge.
+acme_sh_issue_prefix: ''
+
+# When true, causes acme.sh to use the letsencrypt staging servers (passes the --staging flag)
+# Set to false to use live servers.
+acme_sh_staging: true
 
 # REQUIRED TO ISSUE CERTIFICATE: Specify additional arguments to issue the certificate. This is
 # normally the challenge type: for example, -w, --dns, etc. See

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,7 +16,7 @@ galaxy_info:
   # - CC-BY
   license: MIT
 
-  min_ansible_version: 1.2
+  min_ansible_version: 1.9
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,7 @@
     -d {{ acme_sh_secondary_domains|join(" -d ") }}
     {% endif %}
     {{ acme_sh_issue_suffix }}
+    {{ acme_sh_staging | ternary('--staging', '') }}
   args:
     creates: '{{ acme_sh_home }}/{{ acme_sh_primary_domain }}/{{ acme_sh_primary_domain }}.cer'
   when: acme_sh_primary_domain != ''


### PR DESCRIPTION
I'm not sure if this is a change you'd want to merge, but I found it helpful in my own setup to make sure all instances of the role were using --staging during testing and using live servers during deployment:

Rather than making users of this role manage the acme_sh_issue_suffix
variable to enable and disable use of the staging server, implement a
default boolean variable (acme_sh_staging) to add (or not) the
"--staging" flag to the acme.sh command.

Users can still use acme_sh_issue_suffix to selectively set --staging
for some domains.

This changeset updates the README (which was out of date anyway,
referring to the use of acme_sh_env to control staging).

It also bumps the required ansible version to 1.9 (required for the
ternary filter).